### PR TITLE
fix esm import requirements of having extension.

### DIFF
--- a/src/resampleDebug.ts
+++ b/src/resampleDebug.ts
@@ -1,4 +1,4 @@
-import { Interpolation, EPSILON } from './constants';
+import { Interpolation, EPSILON } from './constants.js';
 
 type quat = [number, number, number, number];
 


### PR DESCRIPTION
For ESM and NodeNext style module resolution, you are supposed to have extensions in import statement.  There was one missing in this file.